### PR TITLE
Adding {lang} to the hint to prevent users not using ```{lang}

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ impl serenity::client::EventHandler for Handler {
                     .max_by_key(|line| line.len())
                     .expect("split() is nonempty");
                 let reply = format!(
-                    r#"Hint: use three backticks \`\`\` to wrap your code.
+                    r#"Hint: use three backticks \`\`\`{lang} to wrap your code.
 So this:
 \`\`\`{lang}
 {escaped}


### PR DESCRIPTION
Adding {lang} to the hint to prevent users not using \`\`\`{lang}

Every time I tell people in discord to do what bthint says, the user always forgets to add "php" at the end, which makes the purpose of me telling them to listen to the bot a tad painful.